### PR TITLE
Revamp site styling with Kyocera-inspired theme

### DIFF
--- a/books.css
+++ b/books.css
@@ -2,9 +2,9 @@
 
 /* 页面头部 */
 .page-header {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(120deg, rgba(138, 20, 23, 0.95), rgba(179, 26, 29, 0.88));
     color: white;
-    padding: 120px 0 60px;
+    padding: 140px 0 80px;
     text-align: center;
     position: relative;
     overflow: hidden;
@@ -13,55 +13,62 @@
 .page-header::before {
     content: '';
     position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><pattern id="grain" width="100" height="100" patternUnits="userSpaceOnUse"><circle cx="50" cy="50" r="1" fill="white" opacity="0.1"/></pattern></defs><rect width="100" height="100" fill="url(%23grain)"/></svg>');
-    opacity: 0.3;
+    inset: 0;
+    background: radial-gradient(circle at 30% 25%, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0) 60%),
+                radial-gradient(circle at 75% 30%, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0) 55%);
+    opacity: 0.9;
 }
 
 .page-title {
-    font-size: 3.5rem;
+    font-size: 3.4rem;
     font-weight: 700;
     margin-bottom: 1rem;
     position: relative;
     z-index: 2;
-    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+    letter-spacing: 0.12em;
 }
 
 .page-subtitle {
-    font-size: 1.3rem;
-    margin-bottom: 2rem;
+    font-size: 1.2rem;
+    margin-bottom: 2.2rem;
     opacity: 0.9;
     position: relative;
     z-index: 2;
+    letter-spacing: 0.06em;
 }
 
 .breadcrumb {
     position: relative;
     z-index: 2;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: rgba(255, 255, 255, 0.18);
+    padding: 0.6rem 1.8rem;
+    border-radius: 999px;
+    font-weight: 500;
+    backdrop-filter: blur(10px);
 }
 
 .breadcrumb a {
-    color: rgba(255, 255, 255, 0.8);
+    color: rgba(255, 255, 255, 0.85);
     text-decoration: none;
-    transition: color 0.3s ease;
+    transition: opacity 0.3s ease;
 }
 
 .breadcrumb a:hover {
-    color: white;
+    opacity: 0.8;
 }
 
 /* 分类导航 */
 .category-nav {
-    background: white;
-    padding: 2rem 0;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    background: #fff;
+    padding: 2.2rem 0;
+    border-bottom: 1px solid rgba(179, 26, 29, 0.12);
     position: sticky;
-    top: 70px;
+    top: 78px;
     z-index: 100;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 18px 40px rgba(47, 28, 25, 0.08);
 }
 
 .category-tabs {
@@ -72,34 +79,33 @@
 }
 
 .category-tab {
-    padding: 12px 24px;
-    border: 2px solid #e74c3c;
-    background: transparent;
-    color: #e74c3c;
-    border-radius: 25px;
+    padding: 12px 26px;
+    border: 1px solid transparent;
+    background: rgba(179, 26, 29, 0.08);
+    color: var(--primary-dark);
+    border-radius: 999px;
     font-weight: 600;
     cursor: pointer;
     transition: all 0.3s ease;
     font-size: 0.95rem;
+    letter-spacing: 0.05em;
 }
 
 .category-tab:hover {
-    background: #e74c3c;
-    color: white;
+    background: rgba(179, 26, 29, 0.12);
     transform: translateY(-2px);
-    box-shadow: 0 5px 15px rgba(231, 76, 60, 0.3);
 }
 
 .category-tab.active {
-    background: #e74c3c;
+    background: linear-gradient(135deg, rgba(138, 20, 23, 0.95), rgba(179, 26, 29, 0.85));
     color: white;
-    box-shadow: 0 5px 15px rgba(231, 76, 60, 0.3);
+    box-shadow: 0 18px 35px rgba(179, 26, 29, 0.2);
 }
 
 /* 书籍展示区域 */
 .books-section {
-    padding: 4rem 0;
-    background: #f8f9fa;
+    padding: 4.5rem 0;
+    background: var(--secondary-color);
 }
 
 .books-grid {
@@ -111,17 +117,18 @@
 
 /* 书籍卡片 */
 .book-card {
-    background: white;
-    border-radius: 20px;
+    background: var(--surface-color);
+    border-radius: 26px;
     overflow: hidden;
-    box-shadow: 0 15px 35px rgba(0, 0, 0, 0.1);
-    transition: all 0.3s ease;
+    box-shadow: var(--card-shadow);
+    transition: all 0.35s ease;
     position: relative;
+    border: var(--card-border);
 }
 
 .book-card:hover {
-    transform: translateY(-10px);
-    box-shadow: 0 25px 50px rgba(0, 0, 0, 0.15);
+    transform: translateY(-12px);
+    box-shadow: 0 32px 60px rgba(47, 28, 25, 0.2);
 }
 
 .book-card.hidden {
@@ -131,7 +138,7 @@
 .book-cover {
     position: relative;
     height: 200px;
-    background: linear-gradient(135deg, #667eea, #764ba2);
+    background: linear-gradient(135deg, rgba(138, 20, 23, 0.92), rgba(179, 26, 29, 0.85));
     display: flex;
     align-items: center;
     justify-content: center;
@@ -157,7 +164,7 @@
     position: absolute;
     top: 15px;
     right: 15px;
-    background: rgba(231, 76, 60, 0.9);
+    background: rgba(179, 26, 29, 0.9);
     color: white;
     padding: 5px 12px;
     border-radius: 15px;
@@ -167,18 +174,18 @@
 }
 
 .book-info {
-    padding: 2rem;
+    padding: 2.2rem;
 }
 
 .book-title {
     font-size: 1.4rem;
     font-weight: 700;
-    color: #2c3e50;
+    color: var(--primary-dark);
     margin-bottom: 0.5rem;
 }
 
 .book-subtitle {
-    color: #e74c3c;
+    color: var(--primary-color);
     font-size: 1rem;
     font-weight: 500;
     margin-bottom: 1rem;
@@ -189,19 +196,19 @@
     gap: 1rem;
     margin-bottom: 1rem;
     font-size: 0.9rem;
-    color: #666;
+    color: var(--muted-text);
 }
 
 .book-year, .book-pages {
-    background: #f8f9fa;
-    padding: 4px 8px;
-    border-radius: 10px;
+    background: rgba(179, 26, 29, 0.08);
+    padding: 4px 10px;
+    border-radius: 12px;
     font-size: 0.8rem;
 }
 
 .book-description {
-    color: #666;
-    line-height: 1.6;
+    color: var(--muted-text);
+    line-height: 1.7;
     margin-bottom: 1.5rem;
     font-size: 0.95rem;
 }
@@ -214,10 +221,10 @@
 }
 
 .tag {
-    background: #e8f4fd;
-    color: #3498db;
+    background: rgba(179, 26, 29, 0.08);
+    color: var(--primary-dark);
     padding: 5px 12px;
-    border-radius: 15px;
+    border-radius: 999px;
     font-size: 0.8rem;
     font-weight: 500;
 }
@@ -228,9 +235,9 @@
 }
 
 .btn-detail, .btn-quote {
-    padding: 8px 16px;
+    padding: 10px 18px;
     border: none;
-    border-radius: 20px;
+    border-radius: 999px;
     font-size: 0.9rem;
     font-weight: 600;
     cursor: pointer;
@@ -239,25 +246,26 @@
 }
 
 .btn-detail {
-    background: #e74c3c;
+    background: linear-gradient(135deg, var(--primary-dark), var(--primary-color));
     color: white;
 }
 
 .btn-detail:hover {
-    background: #c0392b;
     transform: translateY(-2px);
+    box-shadow: 0 16px 32px rgba(179, 26, 29, 0.28);
 }
 
 .btn-quote {
-    background: transparent;
-    color: #e74c3c;
-    border: 2px solid #e74c3c;
+    background: rgba(179, 26, 29, 0.08);
+    color: var(--primary-dark);
+    border: 1px solid rgba(179, 26, 29, 0.25);
 }
 
 .btn-quote:hover {
-    background: #e74c3c;
+    background: linear-gradient(135deg, var(--primary-dark), var(--primary-color));
     color: white;
     transform: translateY(-2px);
+    border-color: transparent;
 }
 
 /* 模态框样式 */
@@ -274,16 +282,18 @@
 }
 
 .modal-content {
-    background-color: white;
+    background-color: #fff;
     margin: 5% auto;
     padding: 0;
-    border-radius: 20px;
+    border-radius: 26px;
     width: 90%;
     max-width: 800px;
     max-height: 80vh;
     overflow-y: auto;
     position: relative;
     animation: modalSlideIn 0.3s ease;
+    box-shadow: 0 35px 80px rgba(47, 28, 25, 0.25);
+    border: 1px solid rgba(179, 26, 29, 0.12);
 }
 
 @keyframes modalSlideIn {
@@ -303,18 +313,18 @@
     top: 20px;
     font-size: 28px;
     font-weight: bold;
-    color: #aaa;
+    color: rgba(47, 28, 25, 0.4);
     cursor: pointer;
     z-index: 10;
     transition: color 0.3s ease;
 }
 
 .close:hover {
-    color: #e74c3c;
+    color: var(--primary-color);
 }
 
 .modal-body {
-    padding: 2rem;
+    padding: 2.4rem;
 }
 
 /* 书籍详情样式 */
@@ -332,7 +342,7 @@
 .book-detail-image {
     width: 150px;
     height: 150px;
-    background: linear-gradient(135deg, #667eea, #764ba2);
+    background: linear-gradient(135deg, rgba(138, 20, 23, 0.92), rgba(179, 26, 29, 0.85));
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -347,7 +357,7 @@
 
 .book-detail-title {
     font-size: 2rem;
-    color: #2c3e50;
+    color: var(--primary-dark);
     margin-bottom: 1rem;
 }
 
@@ -359,15 +369,15 @@
 }
 
 .meta-item {
-    background: #f8f9fa;
-    padding: 8px 12px;
-    border-radius: 10px;
+    background: rgba(179, 26, 29, 0.08);
+    padding: 8px 14px;
+    border-radius: 12px;
     font-size: 0.9rem;
-    color: #666;
+    color: var(--primary-dark);
 }
 
 .book-detail-description h3 {
-    color: #2c3e50;
+    color: var(--primary-dark);
     font-size: 1.2rem;
     margin-bottom: 1rem;
     margin-top: 1.5rem;
@@ -378,14 +388,14 @@
 }
 
 .book-detail-description p {
-    color: #666;
-    line-height: 1.7;
+    color: var(--muted-text);
+    line-height: 1.8;
     margin-bottom: 1rem;
 }
 
 .book-detail-description ul {
-    color: #666;
-    line-height: 1.7;
+    color: var(--muted-text);
+    line-height: 1.8;
     margin-bottom: 1rem;
     padding-left: 1.5rem;
 }
@@ -401,7 +411,7 @@
 
 .quote-title {
     font-size: 2rem;
-    color: #2c3e50;
+    color: var(--primary-dark);
     margin-bottom: 2rem;
 }
 
@@ -412,22 +422,22 @@
 }
 
 .quote-item {
-    background: #f8f9fa;
+    background: rgba(179, 26, 29, 0.08);
     padding: 2rem;
-    border-radius: 15px;
-    border-left: 4px solid #e74c3c;
+    border-radius: 18px;
+    border-left: 4px solid var(--primary-color);
 }
 
 .quote-item blockquote {
     font-size: 1.3rem;
-    color: #2c3e50;
+    color: var(--primary-dark);
     font-style: italic;
     margin-bottom: 1rem;
     line-height: 1.6;
 }
 
 .quote-item cite {
-    color: #e74c3c;
+    color: var(--primary-color);
     font-weight: 600;
     font-size: 1rem;
 }

--- a/sitemap.css
+++ b/sitemap.css
@@ -2,9 +2,9 @@
 
 /* 页面头部 */
 .page-header {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(120deg, rgba(138, 20, 23, 0.95), rgba(179, 26, 29, 0.88));
     color: white;
-    padding: 80px 0 40px;
+    padding: 110px 0 70px;
     text-align: center;
     position: relative;
     overflow: hidden;
@@ -13,12 +13,10 @@
 .page-header::before {
     content: '';
     position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><pattern id="grain" width="100" height="100" patternUnits="userSpaceOnUse"><circle cx="25" cy="25" r="1" fill="white" opacity="0.1"/><circle cx="75" cy="75" r="1" fill="white" opacity="0.1"/><circle cx="50" cy="10" r="0.5" fill="white" opacity="0.1"/><circle cx="10" cy="60" r="0.5" fill="white" opacity="0.1"/><circle cx="90" cy="40" r="0.5" fill="white" opacity="0.1"/></pattern></defs><rect width="100" height="100" fill="url(%23grain)"/></svg>');
-    opacity: 0.3;
+    inset: 0;
+    background: radial-gradient(circle at 25% 25%, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0) 60%),
+                radial-gradient(circle at 75% 30%, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0) 55%);
+    opacity: 0.9;
 }
 
 .page-title {
@@ -27,28 +25,33 @@
     margin-bottom: 1rem;
     position: relative;
     z-index: 1;
+    letter-spacing: 0.1em;
 }
 
 .page-subtitle {
-    font-size: 1.2rem;
+    font-size: 1.1rem;
     opacity: 0.9;
     margin-bottom: 2rem;
     position: relative;
     z-index: 1;
+    letter-spacing: 0.05em;
 }
 
 .breadcrumb {
-    background: rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.18);
     backdrop-filter: blur(10px);
-    padding: 0.5rem 1.5rem;
-    border-radius: 25px;
-    display: inline-block;
+    padding: 0.6rem 1.8rem;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
     position: relative;
     z-index: 1;
+    font-weight: 500;
 }
 
 .breadcrumb a {
-    color: white;
+    color: rgba(255, 255, 255, 0.85);
     text-decoration: none;
     transition: opacity 0.3s ease;
 }
@@ -59,8 +62,8 @@
 
 /* 网站地图内容区域 */
 .sitemap-section {
-    padding: 60px 0;
-    background: #f8f9fa;
+    padding: 70px 0;
+    background: var(--secondary-color);
 }
 
 .sitemap-group {
@@ -70,7 +73,7 @@
 .group-title {
     font-size: 2rem;
     font-weight: 600;
-    color: #2c3e50;
+    color: var(--primary-dark);
     margin-bottom: 30px;
     display: flex;
     align-items: center;
@@ -85,12 +88,12 @@
     left: 0;
     width: 60px;
     height: 3px;
-    background: linear-gradient(90deg, #667eea, #764ba2);
-    border-radius: 2px;
+    background: var(--primary-color);
+    border-radius: 999px;
 }
 
 .group-title i {
-    color: #667eea;
+    color: var(--primary-color);
     font-size: 1.5rem;
 }
 
@@ -104,21 +107,21 @@
 
 /* 网站地图卡片 */
 .sitemap-card {
-    background: white;
-    border-radius: 15px;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+    background: var(--surface-color);
+    border-radius: 24px;
+    box-shadow: var(--card-shadow);
     overflow: hidden;
-    transition: all 0.3s ease;
-    border: 1px solid rgba(0, 0, 0, 0.05);
+    transition: all 0.35s ease;
+    border: var(--card-border);
 }
 
 .sitemap-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
+    transform: translateY(-10px);
+    box-shadow: 0 30px 60px rgba(47, 28, 25, 0.2);
 }
 
 .sitemap-card.main-page {
-    border: 2px solid #667eea;
+    border: 2px solid rgba(179, 26, 29, 0.4);
     position: relative;
 }
 
@@ -127,16 +130,16 @@
     position: absolute;
     top: 15px;
     right: 15px;
-    background: #667eea;
+    background: linear-gradient(135deg, var(--primary-dark), var(--primary-color));
     color: white;
-    padding: 5px 10px;
+    padding: 5px 12px;
     border-radius: 15px;
     font-size: 0.8rem;
     font-weight: 600;
 }
 
 .card-header {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, rgba(138, 20, 23, 0.95), rgba(179, 26, 29, 0.85));
     color: white;
     padding: 25px;
     display: flex;
@@ -160,13 +163,13 @@
 }
 
 .card-content p {
-    color: #666;
+    color: var(--muted-text);
     margin-bottom: 20px;
-    line-height: 1.6;
+    line-height: 1.7;
 }
 
 .card-content h4 {
-    color: #2c3e50;
+    color: var(--primary-dark);
     margin-bottom: 10px;
     font-size: 1rem;
     font-weight: 600;
@@ -192,38 +195,38 @@
 
 .card-content li::before {
     content: '•';
-    color: #667eea;
+    color: var(--primary-color);
     font-weight: bold;
     position: absolute;
     left: 0;
 }
 
 .card-content a {
-    color: #667eea;
+    color: var(--primary-dark);
     text-decoration: none;
     transition: color 0.3s ease;
 }
 
 .card-content a:hover {
-    color: #764ba2;
+    color: var(--primary-color);
 }
 
 /* 访问按钮 */
 .btn-visit {
     display: inline-block;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, var(--primary-dark), var(--primary-color));
     color: white;
-    padding: 12px 25px;
-    border-radius: 25px;
+    padding: 12px 28px;
+    border-radius: 999px;
     text-decoration: none;
     font-weight: 600;
     transition: all 0.3s ease;
-    box-shadow: 0 5px 15px rgba(102, 126, 234, 0.3);
+    box-shadow: 0 12px 28px rgba(179, 26, 29, 0.25);
 }
 
 .btn-visit:hover {
     transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(102, 126, 234, 0.4);
+    box-shadow: 0 20px 38px rgba(179, 26, 29, 0.3);
     color: white;
 }
 
@@ -235,15 +238,15 @@
 }
 
 .nav-category {
-    background: white;
-    border-radius: 15px;
+    background: var(--surface-color);
+    border-radius: 20px;
     padding: 25px;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-    border: 1px solid rgba(0, 0, 0, 0.05);
+    box-shadow: var(--card-shadow);
+    border: var(--card-border);
 }
 
 .nav-category h3 {
-    color: #2c3e50;
+    color: var(--primary-dark);
     margin-bottom: 20px;
     font-size: 1.2rem;
     font-weight: 600;
@@ -256,7 +259,7 @@
     content: '';
     width: 4px;
     height: 20px;
-    background: linear-gradient(135deg, #667eea, #764ba2);
+    background: var(--primary-color);
     border-radius: 2px;
 }
 
@@ -271,19 +274,19 @@
     align-items: center;
     gap: 12px;
     padding: 12px 15px;
-    background: #f8f9fa;
-    border-radius: 10px;
-    color: #555;
+    background: rgba(179, 26, 29, 0.08);
+    border-radius: 14px;
+    color: var(--primary-dark);
     text-decoration: none;
     transition: all 0.3s ease;
     border: 1px solid transparent;
 }
 
 .quick-link:hover {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, var(--primary-dark), var(--primary-color));
     color: white;
     transform: translateX(5px);
-    box-shadow: 0 5px 15px rgba(102, 126, 234, 0.3);
+    box-shadow: 0 12px 28px rgba(179, 26, 29, 0.25);
 }
 
 .quick-link i {
@@ -294,11 +297,11 @@
 
 /* 文件结构样式 */
 .file-structure code {
-    background: #f8f9fa;
+    background: rgba(179, 26, 29, 0.08);
     padding: 2px 6px;
     border-radius: 4px;
     font-family: 'Courier New', monospace;
-    color: #667eea;
+    color: var(--primary-dark);
     font-weight: 600;
 }
 
@@ -308,7 +311,7 @@
 }
 
 .compatibility h4 {
-    color: #2c3e50;
+    color: var(--primary-dark);
     margin-bottom: 10px;
     font-size: 1rem;
     font-weight: 600;
@@ -411,12 +414,12 @@
 }
 
 .sitemap-section::-webkit-scrollbar-thumb {
-    background: linear-gradient(135deg, #667eea, #764ba2);
+    background: linear-gradient(135deg, var(--primary-dark), var(--primary-color));
     border-radius: 4px;
 }
 
 .sitemap-section::-webkit-scrollbar-thumb:hover {
-    background: linear-gradient(135deg, #5a6fd8, #6a4190);
+    background: linear-gradient(135deg, rgba(138, 20, 23, 0.95), rgba(179, 26, 29, 0.85));
 }
 
 /* 打印样式 */

--- a/stories.css
+++ b/stories.css
@@ -2,9 +2,9 @@
 
 /* 页面头部 */
 .page-header {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(120deg, rgba(138, 20, 23, 0.95), rgba(179, 26, 29, 0.88));
     color: white;
-    padding: 80px 0 40px;
+    padding: 110px 0 70px;
     text-align: center;
     position: relative;
     overflow: hidden;
@@ -13,12 +13,10 @@
 .page-header::before {
     content: '';
     position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><pattern id="grain" width="100" height="100" patternUnits="userSpaceOnUse"><circle cx="25" cy="25" r="1" fill="white" opacity="0.1"/><circle cx="75" cy="75" r="1" fill="white" opacity="0.1"/><circle cx="50" cy="10" r="0.5" fill="white" opacity="0.1"/><circle cx="10" cy="60" r="0.5" fill="white" opacity="0.1"/><circle cx="90" cy="40" r="0.5" fill="white" opacity="0.1"/></pattern></defs><rect width="100" height="100" fill="url(%23grain)"/></svg>');
-    opacity: 0.3;
+    inset: 0;
+    background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0) 60%),
+                radial-gradient(circle at 80% 30%, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0) 55%);
+    opacity: 0.9;
 }
 
 .page-title {
@@ -27,25 +25,28 @@
     margin-bottom: 1rem;
     position: relative;
     z-index: 1;
+    letter-spacing: 0.1em;
 }
 
 .page-subtitle {
     font-size: 1.2rem;
     opacity: 0.9;
-    margin-bottom: 2rem;
+    margin-bottom: 2.2rem;
     position: relative;
     z-index: 1;
+    letter-spacing: 0.05em;
 }
 
 .breadcrumb {
-    background: rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.18);
     backdrop-filter: blur(10px);
-    padding: 0.5rem 1.5rem;
-    border-radius: 25px;
+    padding: 0.6rem 1.8rem;
+    border-radius: 999px;
     display: inline-block;
     margin-bottom: 2rem;
     position: relative;
     z-index: 1;
+    font-weight: 500;
 }
 
 .breadcrumb a {
@@ -72,10 +73,10 @@
     display: flex;
     align-items: center;
     gap: 10px;
-    background: rgba(255, 255, 255, 0.2);
-    backdrop-filter: blur(10px);
-    padding: 10px 20px;
-    border-radius: 25px;
+    background: rgba(255, 255, 255, 0.18);
+    backdrop-filter: blur(12px);
+    padding: 12px 24px;
+    border-radius: 999px;
     font-weight: 600;
 }
 
@@ -86,12 +87,13 @@
 
 /* 分类导航 */
 .category-nav {
-    background: white;
-    padding: 20px 0;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    background: #fff;
+    padding: 22px 0;
+    box-shadow: 0 18px 40px rgba(47, 28, 25, 0.08);
     position: sticky;
-    top: 0;
+    top: 78px;
     z-index: 100;
+    border-bottom: 1px solid rgba(179, 26, 29, 0.12);
 }
 
 .category-tabs {
@@ -102,31 +104,32 @@
 }
 
 .category-tab {
-    background: #f8f9fa;
-    border: 2px solid transparent;
-    padding: 12px 25px;
-    border-radius: 25px;
+    background: rgba(179, 26, 29, 0.08);
+    border: 1px solid transparent;
+    padding: 12px 26px;
+    border-radius: 999px;
     cursor: pointer;
     transition: all 0.3s ease;
     font-weight: 600;
-    color: #666;
+    color: var(--primary-dark);
+    letter-spacing: 0.04em;
 }
 
 .category-tab:hover {
-    background: #e9ecef;
+    background: rgba(179, 26, 29, 0.12);
     transform: translateY(-2px);
 }
 
 .category-tab.active {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, rgba(138, 20, 23, 0.95), rgba(179, 26, 29, 0.85));
     color: white;
-    box-shadow: 0 5px 15px rgba(102, 126, 234, 0.3);
+    box-shadow: 0 18px 35px rgba(179, 26, 29, 0.2);
 }
 
 /* 故事展示区域 */
 .stories-section {
-    padding: 60px 0;
-    background: #f8f9fa;
+    padding: 70px 0;
+    background: var(--secondary-color);
 }
 
 .stories-grid {
@@ -138,25 +141,25 @@
 
 /* 故事卡片 */
 .story-card {
-    background: white;
-    border-radius: 15px;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+    background: var(--surface-color);
+    border-radius: 26px;
+    box-shadow: var(--card-shadow);
     overflow: hidden;
-    transition: all 0.3s ease;
-    border: 1px solid rgba(0, 0, 0, 0.05);
+    transition: all 0.35s ease;
+    border: var(--card-border);
     position: relative;
 }
 
 .story-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
+    transform: translateY(-10px);
+    box-shadow: 0 32px 60px rgba(47, 28, 25, 0.2);
 }
 
 .story-number {
     position: absolute;
     top: 20px;
     right: 20px;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, rgba(138, 20, 23, 0.95), rgba(179, 26, 29, 0.85));
     color: white;
     width: 40px;
     height: 40px;
@@ -166,17 +169,17 @@
     justify-content: center;
     font-weight: 700;
     font-size: 1.1rem;
-    box-shadow: 0 5px 15px rgba(102, 126, 234, 0.3);
+    box-shadow: 0 12px 28px rgba(179, 26, 29, 0.3);
 }
 
 .story-content {
-    padding: 30px;
+    padding: 32px;
 }
 
 .story-title {
     font-size: 1.4rem;
     font-weight: 600;
-    color: #2c3e50;
+    color: var(--primary-dark);
     margin-bottom: 15px;
     line-height: 1.3;
 }
@@ -188,16 +191,16 @@
 }
 
 .story-category {
-    background: #e3f2fd;
-    color: #1976d2;
-    padding: 4px 12px;
-    border-radius: 15px;
+    background: rgba(179, 26, 29, 0.12);
+    color: var(--primary-dark);
+    padding: 6px 14px;
+    border-radius: 999px;
     font-size: 0.85rem;
     font-weight: 600;
 }
 
 .story-time {
-    color: #666;
+    color: var(--muted-text);
     font-size: 0.85rem;
     display: flex;
     align-items: center;
@@ -210,8 +213,8 @@
 }
 
 .story-excerpt {
-    color: #666;
-    line-height: 1.6;
+    color: var(--muted-text);
+    line-height: 1.7;
     margin-bottom: 20px;
     display: -webkit-box;
     -webkit-line-clamp: 3;
@@ -227,29 +230,29 @@
 }
 
 .tag {
-    background: #f8f9fa;
-    color: #666;
-    padding: 4px 10px;
-    border-radius: 12px;
+    background: rgba(179, 26, 29, 0.08);
+    color: var(--primary-dark);
+    padding: 5px 12px;
+    border-radius: 999px;
     font-size: 0.8rem;
-    border: 1px solid #e9ecef;
+    border: 1px solid rgba(179, 26, 29, 0.2);
 }
 
 .btn-read-story {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, var(--primary-dark), var(--primary-color));
     color: white;
     border: none;
-    padding: 12px 25px;
-    border-radius: 25px;
+    padding: 12px 26px;
+    border-radius: 999px;
     cursor: pointer;
     font-weight: 600;
     transition: all 0.3s ease;
-    box-shadow: 0 5px 15px rgba(102, 126, 234, 0.3);
+    box-shadow: 0 12px 28px rgba(179, 26, 29, 0.24);
 }
 
 .btn-read-story:hover {
     transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(102, 126, 234, 0.4);
+    box-shadow: 0 20px 38px rgba(179, 26, 29, 0.3);
 }
 
 /* 加载更多按钮 */
@@ -260,10 +263,10 @@
 
 .btn-load-more {
     background: white;
-    border: 2px solid #667eea;
-    color: #667eea;
-    padding: 15px 30px;
-    border-radius: 25px;
+    border: 1px solid rgba(179, 26, 29, 0.3);
+    color: var(--primary-dark);
+    padding: 15px 34px;
+    border-radius: 999px;
     cursor: pointer;
     font-weight: 600;
     transition: all 0.3s ease;
@@ -273,10 +276,10 @@
 }
 
 .btn-load-more:hover {
-    background: #667eea;
+    background: linear-gradient(135deg, var(--primary-dark), var(--primary-color));
     color: white;
     transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(102, 126, 234, 0.3);
+    box-shadow: 0 20px 38px rgba(179, 26, 29, 0.26);
 }
 
 /* 模态框样式 */
@@ -293,16 +296,17 @@
 }
 
 .modal-content {
-    background-color: white;
+    background-color: #fff;
     margin: 5% auto;
     padding: 0;
-    border-radius: 15px;
+    border-radius: 24px;
     width: 90%;
     max-width: 800px;
     max-height: 80vh;
     overflow-y: auto;
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 35px 80px rgba(47, 28, 25, 0.25);
     animation: modalSlideIn 0.3s ease;
+    border: 1px solid rgba(179, 26, 29, 0.12);
 }
 
 @keyframes modalSlideIn {
@@ -317,10 +321,10 @@
 }
 
 .modal-header {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, var(--primary-dark), var(--primary-color));
     color: white;
     padding: 25px 30px;
-    border-radius: 15px 15px 0 0;
+    border-radius: 24px 24px 0 0;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -348,7 +352,7 @@
 }
 
 .modal-body {
-    padding: 30px;
+    padding: 32px;
 }
 
 .story-meta-modal {
@@ -358,17 +362,17 @@
 }
 
 .story-meta-modal span {
-    background: #f8f9fa;
-    color: #666;
+    background: rgba(179, 26, 29, 0.08);
+    color: var(--primary-dark);
     padding: 6px 15px;
-    border-radius: 20px;
+    border-radius: 999px;
     font-size: 0.9rem;
     font-weight: 600;
 }
 
 .story-content-modal {
-    line-height: 1.8;
-    color: #333;
+    line-height: 1.85;
+    color: var(--text-color);
     margin-bottom: 25px;
     font-size: 1.1rem;
 }
@@ -380,28 +384,28 @@
 }
 
 .story-tags-modal .tag {
-    background: #e3f2fd;
-    color: #1976d2;
+    background: rgba(179, 26, 29, 0.12);
+    color: var(--primary-dark);
     padding: 6px 12px;
-    border-radius: 15px;
+    border-radius: 999px;
     font-size: 0.9rem;
     font-weight: 600;
 }
 
 .modal-footer {
-    padding: 20px 30px;
-    border-top: 1px solid #e9ecef;
+    padding: 22px 32px;
+    border-top: 1px solid rgba(179, 26, 29, 0.12);
     display: flex;
     gap: 15px;
     justify-content: flex-end;
 }
 
 .btn-share, .btn-bookmark {
-    background: #f8f9fa;
-    border: 1px solid #e9ecef;
-    color: #666;
-    padding: 10px 20px;
-    border-radius: 20px;
+    background: rgba(179, 26, 29, 0.08);
+    border: 1px solid rgba(179, 26, 29, 0.18);
+    color: var(--primary-dark);
+    padding: 12px 22px;
+    border-radius: 999px;
     cursor: pointer;
     font-weight: 600;
     transition: all 0.3s ease;
@@ -411,9 +415,9 @@
 }
 
 .btn-share:hover, .btn-bookmark:hover {
-    background: #667eea;
+    background: linear-gradient(135deg, var(--primary-dark), var(--primary-color));
     color: white;
-    border-color: #667eea;
+    border-color: transparent;
 }
 
 /* 响应式设计 */
@@ -521,10 +525,10 @@
 }
 
 .modal-content::-webkit-scrollbar-thumb {
-    background: linear-gradient(135deg, #667eea, #764ba2);
+    background: linear-gradient(135deg, var(--primary-dark), var(--primary-color));
     border-radius: 4px;
 }
 
 .modal-content::-webkit-scrollbar-thumb:hover {
-    background: linear-gradient(135deg, #5a6fd8, #6a4190);
-} 
+    background: linear-gradient(135deg, rgba(138, 20, 23, 0.95), rgba(179, 26, 29, 0.85));
+}

--- a/styles.css
+++ b/styles.css
@@ -5,11 +5,33 @@
     box-sizing: border-box;
 }
 
+:root {
+    --primary-color: #b31a1d;
+    --primary-dark: #8a1417;
+    --primary-light: #f6e9e5;
+    --secondary-color: #f0e6d8;
+    --text-color: #2f1c19;
+    --muted-text: #5c4b44;
+    --card-shadow: 0 22px 45px rgba(47, 28, 25, 0.12);
+    --card-border: 1px solid rgba(179, 26, 29, 0.12);
+    --surface-color: #ffffff;
+    --background-color: #fbf7f2;
+}
+
 body {
     font-family: 'Noto Serif SC', 'Times New Roman', serif;
     line-height: 1.6;
-    color: #333;
-    background-color: #fff;
+    color: var(--text-color);
+    background: var(--background-color);
+    letter-spacing: 0.01em;
+}
+
+a {
+    color: var(--primary-dark);
+}
+
+p {
+    color: var(--muted-text);
 }
 
 .container {
@@ -23,9 +45,10 @@ body {
     position: fixed;
     top: 0;
     width: 100%;
-    background: rgba(255, 255, 255, 0.95);
-    backdrop-filter: blur(10px);
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    background: rgba(255, 255, 255, 0.88);
+    backdrop-filter: blur(12px);
+    border-bottom: 1px solid rgba(179, 26, 29, 0.15);
+    box-shadow: 0 18px 40px rgba(47, 28, 25, 0.08);
     z-index: 1000;
     transition: all 0.3s ease;
 }
@@ -33,24 +56,25 @@ body {
 .nav-container {
     max-width: 1200px;
     margin: 0 auto;
-    padding: 0 20px;
+    padding: 0 28px;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    height: 70px;
+    height: 78px;
 }
 
 .nav-logo h2 {
-    font-size: 1.8rem;
+    font-size: 1.75rem;
     font-weight: 700;
-    color: #2c3e50;
-    letter-spacing: 1px;
+    color: var(--primary-dark);
+    letter-spacing: 0.08em;
 }
 
 .nav-menu {
     display: flex;
     list-style: none;
-    gap: 2rem;
+    gap: 1.5rem;
+    align-items: center;
 }
 
 /* 收藏按钮样式 */
@@ -63,21 +87,21 @@ body {
     display: flex;
     align-items: center;
     gap: 8px;
-    padding: 10px 16px;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    padding: 10px 18px;
+    background: linear-gradient(135deg, var(--primary-dark) 0%, var(--primary-color) 100%);
     color: white;
     border: none;
-    border-radius: 25px;
+    border-radius: 999px;
     cursor: pointer;
     font-size: 14px;
     font-weight: 500;
     transition: all 0.3s ease;
-    box-shadow: 0 4px 15px rgba(102, 126, 234, 0.3);
+    box-shadow: 0 12px 28px rgba(179, 26, 29, 0.22);
 }
 
 .bookmark-btn:hover {
     transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(102, 126, 234, 0.4);
+    box-shadow: 0 16px 36px rgba(179, 26, 29, 0.28);
 }
 
 .bookmark-btn:active {
@@ -117,13 +141,13 @@ body {
     top: 100px;
     right: 30px;
     padding: 12px 20px;
-    border-radius: 8px;
+    border-radius: 10px;
     color: white;
     font-weight: 500;
     z-index: 10000;
     transform: translateX(100%);
     transition: transform 0.3s ease;
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 18px 35px rgba(47, 28, 25, 0.2);
 }
 
 .bookmark-message.show {
@@ -140,15 +164,17 @@ body {
 
 .nav-link {
     text-decoration: none;
-    color: #2c3e50;
+    color: var(--text-color);
     font-weight: 500;
     font-size: 1rem;
     transition: color 0.3s ease;
     position: relative;
+    padding-bottom: 4px;
 }
 
-.nav-link:hover {
-    color: #e74c3c;
+.nav-link:hover,
+.nav-link.active {
+    color: var(--primary-color);
 }
 
 .nav-link::after {
@@ -156,13 +182,14 @@ body {
     position: absolute;
     width: 0;
     height: 2px;
-    bottom: -5px;
+    bottom: 0;
     left: 0;
-    background-color: #e74c3c;
+    background-color: var(--primary-color);
     transition: width 0.3s ease;
 }
 
-.nav-link:hover::after {
+.nav-link:hover::after,
+.nav-link.active::after {
     width: 100%;
 }
 
@@ -175,7 +202,7 @@ body {
 .bar {
     width: 25px;
     height: 3px;
-    background-color: #2c3e50;
+    background-color: var(--primary-dark);
     margin: 3px 0;
     transition: 0.3s;
 }
@@ -185,8 +212,9 @@ body {
     min-height: 100vh;
     display: flex;
     align-items: center;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
+    padding: 160px 0 120px;
+    background: linear-gradient(130deg, #ffffff 0%, #fbf7f2 45%, #f2e4d9 100%);
+    color: var(--text-color);
     position: relative;
     overflow: hidden;
 }
@@ -194,97 +222,113 @@ body {
 .hero::before {
     content: '';
     position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><pattern id="grain" width="100" height="100" patternUnits="userSpaceOnUse"><circle cx="50" cy="50" r="1" fill="white" opacity="0.1"/></pattern></defs><rect width="100" height="100" fill="url(%23grain)"/></svg>');
-    opacity: 0.3;
+    top: -15%;
+    right: -18%;
+    width: 55%;
+    height: 140%;
+    background: linear-gradient(130deg, rgba(138, 20, 23, 0.95), rgba(179, 26, 29, 0.85));
+    border-radius: 240px;
+    transform: rotate(-10deg);
+}
+
+.hero::after {
+    content: '';
+    position: absolute;
+    top: 12%;
+    left: -8%;
+    width: 220px;
+    height: 220px;
+    background: radial-gradient(circle at center, rgba(179, 26, 29, 0.18), rgba(179, 26, 29, 0));
+    filter: blur(0px);
 }
 
 .hero-content {
     max-width: 1200px;
     margin: 0 auto;
-    padding: 0 20px;
+    padding: 0 40px;
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 4rem;
+    grid-template-columns: 1.15fr 0.85fr;
+    gap: 4.5rem;
     align-items: center;
     position: relative;
     z-index: 2;
 }
 
 .hero-title {
-    font-size: 4rem;
+    font-size: 3.6rem;
     font-weight: 700;
-    margin-bottom: 1rem;
-    letter-spacing: 2px;
-    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+    margin-bottom: 1.2rem;
+    letter-spacing: 0.12em;
+    color: var(--primary-dark);
 }
 
 .hero-subtitle {
-    font-size: 1.5rem;
-    font-weight: 300;
-    margin-bottom: 2rem;
-    opacity: 0.9;
+    font-size: 1.4rem;
+    font-weight: 400;
+    margin-bottom: 1.5rem;
+    color: var(--text-color);
 }
 
 .hero-description {
-    font-size: 1.2rem;
-    line-height: 1.8;
-    margin-bottom: 3rem;
-    opacity: 0.95;
+    font-size: 1.1rem;
+    line-height: 1.9;
+    margin-bottom: 2.5rem;
+    color: var(--muted-text);
 }
 
 .hero-buttons {
     display: flex;
-    gap: 1rem;
+    gap: 1.2rem;
+    flex-wrap: wrap;
 }
 
 .btn {
-    padding: 12px 30px;
+    padding: 12px 32px;
     border: none;
-    border-radius: 50px;
+    border-radius: 999px;
     font-size: 1rem;
     font-weight: 600;
     text-decoration: none;
     transition: all 0.3s ease;
     cursor: pointer;
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    letter-spacing: 0.04em;
 }
 
 .btn-primary {
-    background: #e74c3c;
-    color: white;
+    background: linear-gradient(135deg, var(--primary-dark), var(--primary-color));
+    color: #fff;
+    box-shadow: 0 18px 30px rgba(179, 26, 29, 0.3);
 }
 
 .btn-primary:hover {
-    background: #c0392b;
     transform: translateY(-2px);
-    box-shadow: 0 10px 20px rgba(231, 76, 60, 0.3);
+    box-shadow: 0 24px 38px rgba(179, 26, 29, 0.35);
 }
 
 .btn-secondary {
     background: transparent;
-    color: white;
-    border: 2px solid white;
+    color: var(--primary-dark);
+    border: 2px solid rgba(179, 26, 29, 0.35);
 }
 
 .btn-secondary:hover {
-    background: white;
-    color: #667eea;
+    background: rgba(179, 26, 29, 0.06);
+    color: var(--primary-dark);
     transform: translateY(-2px);
 }
 
 .btn-tertiary {
-    background: rgba(255, 255, 255, 0.2);
-    color: white;
-    border: 2px solid rgba(255, 255, 255, 0.3);
+    background: rgba(179, 26, 29, 0.08);
+    color: var(--primary-dark);
+    border: 2px solid rgba(179, 26, 29, 0.1);
 }
 
 .btn-tertiary:hover {
-    background: rgba(255, 255, 255, 0.3);
-    border-color: rgba(255, 255, 255, 0.5);
+    background: rgba(179, 26, 29, 0.14);
+    border-color: rgba(179, 26, 29, 0.2);
     transform: translateY(-2px);
 }
 
@@ -292,22 +336,33 @@ body {
     display: flex;
     justify-content: center;
     align-items: center;
+    position: relative;
 }
 
 .portrait-container {
-    width: 300px;
-    height: 400px;
-    border-radius: 20px;
+    width: 320px;
+    height: 430px;
+    border-radius: 28px;
     overflow: hidden;
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
-    border: 3px solid rgba(255, 255, 255, 0.3);
-    backdrop-filter: blur(10px);
-    transition: all 0.3s ease;
+    box-shadow: var(--card-shadow);
+    border: 1px solid rgba(179, 26, 29, 0.15);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(240, 226, 214, 0.6));
+    position: relative;
+    transition: transform 0.4s ease, box-shadow 0.4s ease;
+}
+
+.portrait-container::after {
+    content: '';
+    position: absolute;
+    inset: 18px;
+    border-radius: 20px;
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    pointer-events: none;
 }
 
 .portrait-container:hover {
-    transform: scale(1.05);
-    box-shadow: 0 30px 60px rgba(0, 0, 0, 0.4);
+    transform: translateY(-6px);
+    box-shadow: 0 28px 55px rgba(47, 28, 25, 0.25);
 }
 
 .portrait-image {
@@ -315,41 +370,56 @@ body {
     height: 100%;
     object-fit: cover;
     object-position: center;
-    transition: transform 0.3s ease;
+    transition: transform 0.4s ease;
 }
 
 .portrait-container:hover .portrait-image {
-    transform: scale(1.1);
+    transform: scale(1.05);
 }
 
 /* 章节样式 */
 .section {
-    padding: 100px 0;
+    padding: 110px 0;
+    position: relative;
+}
+
+.section::before {
+    content: '';
+    position: absolute;
+    top: 30px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 120px;
+    height: 6px;
+    background: rgba(179, 26, 29, 0.12);
+    border-radius: 999px;
 }
 
 .section-title {
     text-align: center;
-    font-size: 3rem;
+    font-size: 2.7rem;
     font-weight: 700;
-    margin-bottom: 4rem;
-    color: #2c3e50;
+    margin-bottom: 3.5rem;
+    color: var(--primary-dark);
     position: relative;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
 }
 
 .section-title::after {
     content: '';
     position: absolute;
-    bottom: -10px;
+    bottom: -14px;
     left: 50%;
     transform: translateX(-50%);
-    width: 80px;
-    height: 4px;
-    background: linear-gradient(90deg, #e74c3c, #f39c12);
-    border-radius: 2px;
+    width: 92px;
+    height: 3px;
+    background: var(--primary-color);
+    border-radius: 999px;
 }
 
 .bg-light {
-    background-color: #f8f9fa;
+    background-color: var(--secondary-color);
 }
 
 /* 时间线样式 */
@@ -365,14 +435,15 @@ body {
     left: 50%;
     top: 0;
     bottom: 0;
-    width: 4px;
-    background: linear-gradient(180deg, #e74c3c, #f39c12);
+    width: 3px;
+    background: linear-gradient(180deg, rgba(179, 26, 29, 0.38), rgba(179, 26, 29, 0.08));
     transform: translateX(-50%);
+    border-radius: 999px;
 }
 
 .timeline-item {
     position: relative;
-    margin-bottom: 3rem;
+    margin-bottom: 3.5rem;
     display: flex;
     align-items: center;
 }
@@ -386,40 +457,42 @@ body {
 }
 
 .timeline-date {
-    background: linear-gradient(135deg, #e74c3c, #f39c12);
+    background: linear-gradient(135deg, rgba(138, 20, 23, 0.95), rgba(179, 26, 29, 0.85));
     color: white;
-    padding: 10px 20px;
-    border-radius: 25px;
+    padding: 12px 22px;
+    border-radius: 999px;
     font-weight: 600;
     font-size: 0.9rem;
-    min-width: 120px;
+    min-width: 130px;
     text-align: center;
-    box-shadow: 0 5px 15px rgba(231, 76, 60, 0.3);
+    box-shadow: 0 18px 30px rgba(179, 26, 29, 0.25);
 }
 
 .timeline-content {
-    background: white;
-    padding: 2rem;
-    border-radius: 15px;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+    background: var(--surface-color);
+    padding: 2.4rem;
+    border-radius: 22px;
+    box-shadow: var(--card-shadow);
     margin: 0 2rem;
     flex: 1;
-    transition: transform 0.3s ease;
+    transition: transform 0.35s ease, box-shadow 0.35s ease;
+    border: var(--card-border);
 }
 
 .timeline-content:hover {
-    transform: translateY(-5px);
+    transform: translateY(-8px);
+    box-shadow: 0 28px 60px rgba(47, 28, 25, 0.22);
 }
 
 .timeline-content h3 {
-    color: #2c3e50;
-    font-size: 1.3rem;
+    color: var(--primary-dark);
+    font-size: 1.25rem;
     margin-bottom: 1rem;
 }
 
 .timeline-content p {
-    color: #666;
-    line-height: 1.6;
+    color: var(--muted-text);
+    line-height: 1.75;
 }
 
 /* 思想理念卡片 */
@@ -431,36 +504,38 @@ body {
 }
 
 .philosophy-card {
-    background: white;
+    background: var(--surface-color);
     padding: 2.5rem;
-    border-radius: 20px;
-    box-shadow: 0 15px 35px rgba(0, 0, 0, 0.1);
+    border-radius: 26px;
+    box-shadow: var(--card-shadow);
     text-align: center;
-    transition: all 0.3s ease;
-    border: 1px solid rgba(0, 0, 0, 0.05);
+    transition: all 0.35s ease;
+    border: var(--card-border);
+    position: relative;
 }
 
 .philosophy-card:hover {
-    transform: translateY(-10px);
-    box-shadow: 0 25px 50px rgba(0, 0, 0, 0.15);
+    transform: translateY(-12px);
+    box-shadow: 0 30px 65px rgba(47, 28, 25, 0.18);
 }
 
 .card-icon {
     font-size: 3rem;
     margin-bottom: 1.5rem;
     display: block;
+    color: var(--primary-color);
 }
 
 .philosophy-card h3 {
-    color: #2c3e50;
-    font-size: 1.4rem;
+    color: var(--primary-dark);
+    font-size: 1.3rem;
     margin-bottom: 1rem;
     font-weight: 600;
 }
 
 .philosophy-card p {
-    color: #666;
-    line-height: 1.6;
+    color: var(--muted-text);
+    line-height: 1.7;
 }
 
 /* 著作文献 */
@@ -472,21 +547,22 @@ body {
 }
 
 .work-card {
-    background: white;
-    border-radius: 20px;
+    background: var(--surface-color);
+    border-radius: 26px;
     overflow: hidden;
-    box-shadow: 0 15px 35px rgba(0, 0, 0, 0.1);
-    transition: all 0.3s ease;
+    box-shadow: var(--card-shadow);
+    transition: all 0.35s ease;
+    border: var(--card-border);
 }
 
 .work-card:hover {
-    transform: translateY(-10px);
-    box-shadow: 0 25px 50px rgba(0, 0, 0, 0.15);
+    transform: translateY(-12px);
+    box-shadow: 0 32px 60px rgba(47, 28, 25, 0.2);
 }
 
 .work-image {
     height: 200px;
-    background: linear-gradient(135deg, #667eea, #764ba2);
+    background: linear-gradient(135deg, rgba(138, 20, 23, 0.92), rgba(179, 26, 29, 0.85));
     display: flex;
     align-items: center;
     justify-content: center;
@@ -502,15 +578,15 @@ body {
 }
 
 .work-content h3 {
-    color: #2c3e50;
-    font-size: 1.3rem;
+    color: var(--primary-dark);
+    font-size: 1.25rem;
     margin-bottom: 1rem;
     font-weight: 600;
 }
 
 .work-content p {
-    color: #666;
-    line-height: 1.6;
+    color: var(--muted-text);
+    line-height: 1.7;
     margin-bottom: 1.5rem;
 }
 
@@ -521,12 +597,13 @@ body {
 }
 
 .tag {
-    background: #e8f4fd;
-    color: #3498db;
-    padding: 5px 12px;
-    border-radius: 15px;
-    font-size: 0.8rem;
+    background: rgba(179, 26, 29, 0.08);
+    color: var(--primary-dark);
+    padding: 6px 14px;
+    border-radius: 999px;
+    font-size: 0.78rem;
     font-weight: 500;
+    letter-spacing: 0.04em;
 }
 
 /* 核心价值主张 */
@@ -538,29 +615,30 @@ body {
 }
 
 .value-card {
-    background: white;
-    padding: 2rem;
-    border-radius: 15px;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+    background: var(--surface-color);
+    padding: 2.2rem;
+    border-radius: 24px;
+    box-shadow: var(--card-shadow);
     text-align: center;
-    transition: all 0.3s ease;
+    transition: all 0.35s ease;
+    border: var(--card-border);
 }
 
 .value-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
+    transform: translateY(-10px);
+    box-shadow: 0 30px 60px rgba(47, 28, 25, 0.18);
 }
 
 .value-card h3 {
-    color: #2c3e50;
-    font-size: 1.3rem;
+    color: var(--primary-dark);
+    font-size: 1.2rem;
     margin-bottom: 1rem;
     font-weight: 600;
 }
 
 .value-card p {
-    color: #666;
-    line-height: 1.6;
+    color: var(--muted-text);
+    line-height: 1.7;
 }
 
 /* 名言精选 */
@@ -572,17 +650,18 @@ body {
 }
 
 .quote-card {
-    background: white;
-    padding: 2rem;
-    border-radius: 15px;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-    transition: all 0.3s ease;
+    background: var(--surface-color);
+    padding: 2.2rem;
+    border-radius: 26px;
+    box-shadow: var(--card-shadow);
+    transition: all 0.35s ease;
     position: relative;
+    border: var(--card-border);
 }
 
 .quote-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
+    transform: translateY(-10px);
+    box-shadow: 0 28px 60px rgba(47, 28, 25, 0.2);
 }
 
 .quote-card::before {
@@ -591,20 +670,20 @@ body {
     top: -10px;
     left: 20px;
     font-size: 3rem;
-    color: #e74c3c;
+    color: var(--primary-color);
     font-family: serif;
 }
 
 .quote-card blockquote {
     font-size: 1.1rem;
-    color: #2c3e50;
+    color: var(--primary-dark);
     font-style: italic;
     margin-bottom: 1rem;
-    line-height: 1.6;
+    line-height: 1.7;
 }
 
 .quote-card cite {
-    color: #e74c3c;
+    color: var(--primary-color);
     font-weight: 600;
     font-size: 0.9rem;
 }
@@ -618,33 +697,34 @@ body {
 }
 
 .local-card {
-    background: white;
-    padding: 2rem;
-    border-radius: 15px;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-    transition: all 0.3s ease;
+    background: var(--surface-color);
+    padding: 2.2rem;
+    border-radius: 24px;
+    box-shadow: var(--card-shadow);
+    transition: all 0.35s ease;
+    border: var(--card-border);
 }
 
 .local-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
+    transform: translateY(-10px);
+    box-shadow: 0 28px 60px rgba(47, 28, 25, 0.2);
 }
 
 .local-card h3 {
-    color: #2c3e50;
-    font-size: 1.3rem;
+    color: var(--primary-dark);
+    font-size: 1.25rem;
     margin-bottom: 1rem;
     font-weight: 600;
 }
 
 .local-card p {
-    color: #666;
-    line-height: 1.6;
+    color: var(--muted-text);
+    line-height: 1.7;
     margin-bottom: 1rem;
 }
 
 .local-details h4 {
-    color: #e74c3c;
+    color: var(--primary-color);
     font-size: 1rem;
     margin-bottom: 0.5rem;
     font-weight: 600;
@@ -656,7 +736,7 @@ body {
 }
 
 .local-details li {
-    color: #666;
+    color: var(--muted-text);
     margin-bottom: 0.3rem;
     padding-left: 1rem;
     position: relative;
@@ -664,7 +744,7 @@ body {
 
 .local-details li::before {
     content: '•';
-    color: #e74c3c;
+    color: var(--primary-color);
     position: absolute;
     left: 0;
 }
@@ -676,36 +756,38 @@ body {
 }
 
 .faq-item {
-    background: white;
+    background: var(--surface-color);
     margin-bottom: 1rem;
-    border-radius: 10px;
-    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+    border-radius: 18px;
+    box-shadow: var(--card-shadow);
     overflow: hidden;
-    transition: all 0.3s ease;
+    transition: all 0.35s ease;
+    border: var(--card-border);
 }
 
 .faq-item:hover {
-    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 26px 55px rgba(47, 28, 25, 0.2);
 }
 
 .faq-item h3 {
-    background: #f8f9fa;
-    padding: 1.5rem 2rem;
+    background: rgba(179, 26, 29, 0.06);
+    padding: 1.6rem 2.2rem;
     margin: 0;
-    color: #2c3e50;
-    font-size: 1.1rem;
+    color: var(--primary-dark);
+    font-size: 1.05rem;
     font-weight: 600;
     cursor: pointer;
-    transition: background-color 0.3s ease;
+    transition: background-color 0.3s ease, color 0.3s ease;
+    position: relative;
 }
 
 .faq-item h3:hover {
-    background: #e9ecef;
+    background: rgba(179, 26, 29, 0.12);
 }
 
 .faq-item.active h3 {
-    background: #e74c3c;
-    color: white;
+    background: linear-gradient(135deg, var(--primary-dark), var(--primary-color));
+    color: #fff;
 }
 
 .faq-item h3::after {
@@ -717,6 +799,7 @@ body {
     font-size: 1.2rem;
     font-weight: bold;
     transition: transform 0.3s ease;
+    color: inherit;
 }
 
 .faq-item.active h3::after {
@@ -724,12 +807,12 @@ body {
 }
 
 .faq-answer {
-    padding: 0 2rem 1.5rem;
+    padding: 0 2.2rem 1.8rem;
 }
 
 .faq-answer p {
-    color: #666;
-    line-height: 1.6;
+    color: var(--muted-text);
+    line-height: 1.7;
     margin-bottom: 0.5rem;
 }
 
@@ -740,7 +823,7 @@ body {
 }
 
 .faq-answer li {
-    color: #666;
+    color: var(--muted-text);
     margin-bottom: 0.3rem;
     padding-left: 1rem;
     position: relative;
@@ -748,7 +831,7 @@ body {
 
 .faq-answer li::before {
     content: '•';
-    color: #e74c3c;
+    color: var(--primary-color);
     position: absolute;
     left: 0;
 }
@@ -762,9 +845,9 @@ body {
 }
 
 .legacy-text h3 {
-    color: #2c3e50;
-    font-size: 1.4rem;
-    margin-bottom: 1rem;
+    color: var(--primary-dark);
+    font-size: 1.25rem;
+    margin-bottom: 0.8rem;
     margin-top: 2rem;
     font-weight: 600;
 }
@@ -774,18 +857,19 @@ body {
 }
 
 .legacy-text p {
-    color: #666;
-    line-height: 1.7;
+    color: var(--muted-text);
+    line-height: 1.8;
     margin-bottom: 1.5rem;
 }
 
 .legacy-quote {
-    background: white;
-    padding: 2.5rem;
-    border-radius: 20px;
-    box-shadow: 0 15px 35px rgba(0, 0, 0, 0.1);
+    background: var(--surface-color);
+    padding: 2.6rem;
+    border-radius: 26px;
+    box-shadow: var(--card-shadow);
     text-align: center;
     position: relative;
+    border: var(--card-border);
 }
 
 .legacy-quote::before {
@@ -794,47 +878,48 @@ body {
     top: -20px;
     left: 30px;
     font-size: 4rem;
-    color: #e74c3c;
+    color: var(--primary-color);
     font-family: serif;
 }
 
 .legacy-quote blockquote {
     font-size: 1.3rem;
-    color: #2c3e50;
+    color: var(--primary-dark);
     font-style: italic;
     margin-bottom: 1rem;
     line-height: 1.6;
 }
 
 .legacy-quote cite {
-    color: #e74c3c;
+    color: var(--primary-color);
     font-weight: 600;
     font-size: 1rem;
 }
 
 /* 页脚 */
 .footer {
-    background: #2c3e50;
-    color: white;
-    padding: 3rem 0 1rem;
+    background: linear-gradient(140deg, #1f0d0e, #3a0f11);
+    color: #fbeeea;
+    padding: 3.5rem 0 1.5rem;
 }
 
 .footer-content {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 2rem;
-    margin-bottom: 2rem;
+    gap: 2.5rem;
+    margin-bottom: 2.5rem;
 }
 
 .footer-section h3 {
-    font-size: 1.2rem;
+    font-size: 1.15rem;
     margin-bottom: 1rem;
-    color: #ecf0f1;
+    color: #fff5f1;
+    letter-spacing: 0.08em;
 }
 
 .footer-section p {
-    color: #bdc3c7;
-    line-height: 1.6;
+    color: rgba(251, 238, 234, 0.7);
+    line-height: 1.7;
 }
 
 .footer-links {
@@ -843,24 +928,25 @@ body {
 }
 
 .footer-links li {
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.55rem;
 }
 
 .footer-links a {
-    color: #bdc3c7;
+    color: rgba(251, 238, 234, 0.7);
     text-decoration: none;
     transition: color 0.3s ease;
 }
 
 .footer-links a:hover {
-    color: #e74c3c;
+    color: #ffcdc2;
 }
 
 .footer-bottom {
-    border-top: 1px solid #34495e;
-    padding-top: 1rem;
+    border-top: 1px solid rgba(251, 238, 234, 0.15);
+    padding-top: 1.2rem;
     text-align: center;
-    color: #95a5a6;
+    color: rgba(251, 238, 234, 0.6);
+    letter-spacing: 0.04em;
 }
 
 /* 响应式设计 */
@@ -872,13 +958,13 @@ body {
     .nav-menu {
         position: fixed;
         left: -100%;
-        top: 70px;
+        top: 78px;
         flex-direction: column;
-        background-color: white;
+        background-color: rgba(255, 255, 255, 0.98);
         width: 100%;
         text-align: center;
         transition: 0.3s;
-        box-shadow: 0 10px 27px rgba(0, 0, 0, 0.05);
+        box-shadow: 0 24px 45px rgba(47, 28, 25, 0.12);
         padding: 2rem 0;
     }
     
@@ -1082,38 +1168,39 @@ body {
     display: flex;
     gap: 1rem;
     align-items: center;
-    padding: 1rem 1.25rem;
-    background: white;
-    border-radius: 12px;
-    box-shadow: 0 6px 20px rgba(0,0,0,0.06);
+    padding: 1.1rem 1.4rem;
+    background: var(--surface-color);
+    border-radius: 18px;
+    box-shadow: var(--card-shadow);
     margin-bottom: 0.8rem;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
     animation: fadeInUp 0.6s ease forwards;
+    border: var(--card-border);
 }
 
 .news-item:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 12px 30px rgba(0,0,0,0.08);
+    transform: translateY(-6px);
+    box-shadow: 0 24px 45px rgba(47, 28, 25, 0.18);
 }
 
 .news-date {
     flex: 0 0 auto;
     font-weight: 700;
-    color: #e74c3c;
-    background: #fff5f3;
-    border: 1px solid #ffe0da;
-    padding: 6px 10px;
-    border-radius: 8px;
+    color: var(--primary-dark);
+    background: rgba(179, 26, 29, 0.12);
+    border: 1px solid rgba(179, 26, 29, 0.25);
+    padding: 6px 12px;
+    border-radius: 10px;
     font-size: 0.9rem;
 }
 
 .news-link {
-    color: #2c3e50;
+    color: var(--primary-dark);
     text-decoration: none;
 }
 
 .news-link:hover {
-    color: #e74c3c;
+    color: var(--primary-color);
 }
 
 /* 新增：精选内容与深入学习栅格 */
@@ -1125,37 +1212,38 @@ body {
 }
 
 .featured-card {
-    background: white;
-    border-radius: 16px;
-    padding: 1.5rem;
+    background: var(--surface-color);
+    border-radius: 22px;
+    padding: 1.7rem;
     text-align: center;
-    box-shadow: 0 10px 25px rgba(0,0,0,0.08);
+    box-shadow: var(--card-shadow);
     text-decoration: none;
     color: inherit;
-    transition: transform 0.25s ease, box-shadow 0.25s ease;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
     animation: fadeInUp 0.6s ease forwards;
+    border: var(--card-border);
 }
 
 .featured-card i {
     font-size: 28px;
-    color: #764ba2;
+    color: var(--primary-color);
 }
 
 .featured-card h3 {
     margin-top: 0.8rem;
     margin-bottom: 0.25rem;
     font-size: 1.1rem;
-    color: #2c3e50;
+    color: var(--primary-dark);
 }
 
 .featured-card p {
-    color: #666;
+    color: var(--muted-text);
     font-size: 0.95rem;
 }
 
 .featured-card:hover {
-    transform: translateY(-6px);
-    box-shadow: 0 16px 40px rgba(0,0,0,0.12);
+    transform: translateY(-10px);
+    box-shadow: 0 26px 55px rgba(47, 28, 25, 0.18);
 }
 
 /* 新增：学习/哲学专题栅格 */
@@ -1167,20 +1255,21 @@ body {
 }
 
 .hub-card {
-    background: white;
-    border-radius: 16px;
-    padding: 1.5rem;
+    background: var(--surface-color);
+    border-radius: 22px;
+    padding: 1.7rem;
     display: block;
     text-decoration: none;
     color: inherit;
-    box-shadow: 0 10px 25px rgba(0,0,0,0.08);
-    transition: transform 0.25s ease, box-shadow 0.25s ease;
+    box-shadow: var(--card-shadow);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
     animation: fadeInUp 0.6s ease forwards;
+    border: var(--card-border);
 }
 
 .hub-card:hover {
-    transform: translateY(-6px);
-    box-shadow: 0 16px 40px rgba(0,0,0,0.12);
+    transform: translateY(-10px);
+    box-shadow: 0 26px 55px rgba(47, 28, 25, 0.18);
 }
 
 .hub-icon {
@@ -1190,7 +1279,7 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
-    background: linear-gradient(135deg, #667eea, #764ba2);
+    background: linear-gradient(135deg, rgba(138, 20, 23, 0.92), rgba(179, 26, 29, 0.85));
     color: #fff;
     font-size: 22px;
     margin-bottom: 0.75rem;
@@ -1198,12 +1287,12 @@ body {
 
 .hub-card h3 {
     font-size: 1.1rem;
-    color: #2c3e50;
+    color: var(--primary-dark);
     margin-bottom: 0.25rem;
 }
 
 .hub-card p {
-    color: #666;
+    color: var(--muted-text);
     font-size: 0.95rem;
 }
 /* 分享功能样式 */
@@ -1213,7 +1302,7 @@ body {
     right: 20px;
     width: 60px;
     height: 60px;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, var(--primary-dark), var(--primary-color));
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -1221,20 +1310,20 @@ body {
     color: white;
     font-size: 24px;
     cursor: pointer;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 18px 38px rgba(47, 28, 25, 0.25);
     transition: all 0.3s ease;
     z-index: 1000;
 }
 
 .floating-share-btn:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 6px 25px rgba(0, 0, 0, 0.2);
+    transform: translateY(-4px);
+    box-shadow: 0 26px 55px rgba(47, 28, 25, 0.3);
 }
 
 .share-tooltip {
     position: absolute;
     right: 70px;
-    background: rgba(0, 0, 0, 0.8);
+    background: rgba(31, 12, 14, 0.92);
     color: white;
     padding: 8px 12px;
     border-radius: 6px;
@@ -1252,7 +1341,7 @@ body {
     top: 50%;
     transform: translateY(-50%);
     border: 5px solid transparent;
-    border-left-color: rgba(0, 0, 0, 0.8);
+    border-left-color: rgba(31, 12, 14, 0.92);
 }
 
 .floating-share-btn:hover .share-tooltip {
@@ -1277,11 +1366,12 @@ body {
     background-color: #fff;
     margin: 5% auto;
     padding: 0;
-    border-radius: 15px;
+    border-radius: 22px;
     width: 90%;
     max-width: 500px;
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 35px 80px rgba(31, 12, 14, 0.25);
     animation: slideIn 0.3s ease;
+    border: 1px solid rgba(179, 26, 29, 0.12);
 }
 
 @keyframes slideIn {
@@ -1296,10 +1386,10 @@ body {
 }
 
 .share-modal-header {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, var(--primary-dark), var(--primary-color));
     color: white;
-    padding: 20px;
-    border-radius: 15px 15px 0 0;
+    padding: 22px;
+    border-radius: 22px 22px 0 0;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -1332,7 +1422,7 @@ body {
 }
 
 .share-modal-body {
-    padding: 30px;
+    padding: 32px;
 }
 
 /* 分享平台按钮样式 */
@@ -1404,7 +1494,7 @@ body {
 
 /* 分享链接部分 */
 .share-link-section {
-    border-top: 1px solid #e5e7eb;
+    border-top: 1px solid rgba(179, 26, 29, 0.12);
     padding-top: 20px;
 }
 
@@ -1412,7 +1502,7 @@ body {
     display: block;
     margin-bottom: 10px;
     font-weight: 600;
-    color: #374151;
+    color: var(--primary-dark);
 }
 
 .share-link-container {
@@ -1423,28 +1513,30 @@ body {
 .share-link-container input {
     flex: 1;
     padding: 12px;
-    border: 2px solid #e5e7eb;
-    border-radius: 8px;
+    border: 1px solid rgba(179, 26, 29, 0.2);
+    border-radius: 12px;
     font-size: 14px;
-    background-color: #f9fafb;
-    color: #6b7280;
+    background-color: rgba(179, 26, 29, 0.05);
+    color: var(--muted-text);
 }
 
 .copy-link-btn {
     padding: 12px 20px;
-    background-color: #6c757d;
+    background: linear-gradient(135deg, var(--primary-dark), var(--primary-color));
     color: white;
     border: none;
-    border-radius: 8px;
+    border-radius: 999px;
     cursor: pointer;
     font-size: 14px;
     font-weight: 500;
-    transition: background-color 0.3s ease;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
     white-space: nowrap;
+    box-shadow: 0 12px 28px rgba(179, 26, 29, 0.24);
 }
 
 .copy-link-btn:hover {
-    background-color: #5a6268;
+    transform: translateY(-2px);
+    box-shadow: 0 18px 35px rgba(179, 26, 29, 0.3);
 }
 
 /* 移动端响应式 */

--- a/videos.css
+++ b/videos.css
@@ -2,9 +2,9 @@
 
 /* 页面头部 */
 .page-header {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(120deg, rgba(138, 20, 23, 0.95), rgba(179, 26, 29, 0.88));
     color: white;
-    padding: 120px 0 60px;
+    padding: 140px 0 80px;
     text-align: center;
     position: relative;
     overflow: hidden;
@@ -13,55 +13,62 @@
 .page-header::before {
     content: '';
     position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><pattern id="grain" width="100" height="100" patternUnits="userSpaceOnUse"><circle cx="50" cy="50" r="1" fill="white" opacity="0.1"/></pattern></defs><rect width="100" height="100" fill="url(%23grain)"/></svg>');
-    opacity: 0.3;
+    inset: 0;
+    background: radial-gradient(circle at 30% 25%, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0) 60%),
+                radial-gradient(circle at 75% 30%, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0) 55%);
+    opacity: 0.9;
 }
 
 .page-title {
-    font-size: 3.5rem;
+    font-size: 3.4rem;
     font-weight: 700;
     margin-bottom: 1rem;
     position: relative;
     z-index: 2;
-    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+    letter-spacing: 0.12em;
 }
 
 .page-subtitle {
-    font-size: 1.3rem;
-    margin-bottom: 2rem;
+    font-size: 1.2rem;
+    margin-bottom: 2.2rem;
     opacity: 0.9;
     position: relative;
     z-index: 2;
+    letter-spacing: 0.06em;
 }
 
 .breadcrumb {
     position: relative;
     z-index: 2;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: rgba(255, 255, 255, 0.18);
+    padding: 0.6rem 1.8rem;
+    border-radius: 999px;
+    font-weight: 500;
+    backdrop-filter: blur(10px);
 }
 
 .breadcrumb a {
-    color: rgba(255, 255, 255, 0.8);
+    color: rgba(255, 255, 255, 0.85);
     text-decoration: none;
-    transition: color 0.3s ease;
+    transition: opacity 0.3s ease;
 }
 
 .breadcrumb a:hover {
-    color: white;
+    opacity: 0.8;
 }
 
 /* 分类导航 */
 .category-nav {
-    background: white;
-    padding: 2rem 0;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    background: #fff;
+    padding: 2.2rem 0;
+    border-bottom: 1px solid rgba(179, 26, 29, 0.12);
     position: sticky;
-    top: 70px;
+    top: 78px;
     z-index: 100;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 18px 40px rgba(47, 28, 25, 0.08);
 }
 
 .category-tabs {
@@ -72,34 +79,33 @@
 }
 
 .category-tab {
-    padding: 12px 24px;
-    border: 2px solid #e74c3c;
-    background: transparent;
-    color: #e74c3c;
-    border-radius: 25px;
+    padding: 12px 26px;
+    border: 1px solid transparent;
+    background: rgba(179, 26, 29, 0.08);
+    color: var(--primary-dark);
+    border-radius: 999px;
     font-weight: 600;
     cursor: pointer;
     transition: all 0.3s ease;
     font-size: 0.95rem;
+    letter-spacing: 0.05em;
 }
 
 .category-tab:hover {
-    background: #e74c3c;
-    color: white;
+    background: rgba(179, 26, 29, 0.12);
     transform: translateY(-2px);
-    box-shadow: 0 5px 15px rgba(231, 76, 60, 0.3);
 }
 
 .category-tab.active {
-    background: #e74c3c;
+    background: linear-gradient(135deg, rgba(138, 20, 23, 0.95), rgba(179, 26, 29, 0.85));
     color: white;
-    box-shadow: 0 5px 15px rgba(231, 76, 60, 0.3);
+    box-shadow: 0 18px 35px rgba(179, 26, 29, 0.2);
 }
 
 /* 视频展示区域 */
 .videos-section {
-    padding: 4rem 0;
-    background: #f8f9fa;
+    padding: 4.5rem 0;
+    background: var(--secondary-color);
 }
 
 .videos-grid {
@@ -111,17 +117,18 @@
 
 /* 视频卡片 */
 .video-card {
-    background: white;
-    border-radius: 20px;
+    background: var(--surface-color);
+    border-radius: 26px;
     overflow: hidden;
-    box-shadow: 0 15px 35px rgba(0, 0, 0, 0.1);
-    transition: all 0.3s ease;
+    box-shadow: var(--card-shadow);
+    transition: all 0.35s ease;
     position: relative;
+    border: var(--card-border);
 }
 
 .video-card:hover {
-    transform: translateY(-10px);
-    box-shadow: 0 25px 50px rgba(0, 0, 0, 0.15);
+    transform: translateY(-12px);
+    box-shadow: 0 32px 60px rgba(47, 28, 25, 0.2);
 }
 
 .video-card.hidden {
@@ -131,7 +138,7 @@
 .video-thumbnail {
     position: relative;
     height: 220px;
-    background: linear-gradient(135deg, #667eea, #764ba2);
+    background: linear-gradient(135deg, rgba(138, 20, 23, 0.92), rgba(179, 26, 29, 0.85));
     display: flex;
     align-items: center;
     justify-content: center;
@@ -194,7 +201,7 @@
     position: absolute;
     top: 15px;
     left: 15px;
-    background: rgba(231, 76, 60, 0.9);
+    background: rgba(179, 26, 29, 0.9);
     color: white;
     padding: 5px 12px;
     border-radius: 15px;
@@ -204,13 +211,13 @@
 }
 
 .video-info {
-    padding: 2rem;
+    padding: 2.2rem;
 }
 
 .video-title {
     font-size: 1.3rem;
     font-weight: 700;
-    color: #2c3e50;
+    color: var(--primary-dark);
     margin-bottom: 1rem;
     line-height: 1.4;
     display: -webkit-box;
@@ -220,8 +227,8 @@
 }
 
 .video-description {
-    color: #666;
-    line-height: 1.6;
+    color: var(--muted-text);
+    line-height: 1.7;
     margin-bottom: 1.5rem;
     font-size: 0.95rem;
     display: -webkit-box;
@@ -235,7 +242,7 @@
     gap: 1rem;
     margin-bottom: 1rem;
     font-size: 0.9rem;
-    color: #666;
+    color: var(--muted-text);
     flex-wrap: wrap;
 }
 
@@ -243,10 +250,11 @@
     display: flex;
     align-items: center;
     gap: 0.3rem;
-    background: #f8f9fa;
-    padding: 4px 8px;
-    border-radius: 10px;
+    background: rgba(179, 26, 29, 0.08);
+    padding: 6px 10px;
+    border-radius: 999px;
     font-size: 0.8rem;
+    color: var(--primary-dark);
 }
 
 .video-tags {
@@ -257,10 +265,10 @@
 }
 
 .tag {
-    background: #e8f4fd;
-    color: #3498db;
+    background: rgba(179, 26, 29, 0.08);
+    color: var(--primary-dark);
     padding: 5px 12px;
-    border-radius: 15px;
+    border-radius: 999px;
     font-size: 0.8rem;
     font-weight: 500;
 }
@@ -271,9 +279,9 @@
 }
 
 .btn-play, .btn-detail {
-    padding: 10px 20px;
+    padding: 12px 20px;
     border: none;
-    border-radius: 20px;
+    border-radius: 999px;
     font-size: 0.9rem;
     font-weight: 600;
     cursor: pointer;
@@ -282,26 +290,26 @@
 }
 
 .btn-play {
-    background: #e74c3c;
+    background: linear-gradient(135deg, var(--primary-dark), var(--primary-color));
     color: white;
 }
 
 .btn-play:hover {
-    background: #c0392b;
     transform: translateY(-2px);
-    box-shadow: 0 5px 15px rgba(231, 76, 60, 0.3);
+    box-shadow: 0 18px 32px rgba(179, 26, 29, 0.28);
 }
 
 .btn-detail {
-    background: transparent;
-    color: #e74c3c;
-    border: 2px solid #e74c3c;
+    background: rgba(179, 26, 29, 0.08);
+    color: var(--primary-dark);
+    border: 1px solid rgba(179, 26, 29, 0.25);
 }
 
 .btn-detail:hover {
-    background: #e74c3c;
+    background: linear-gradient(135deg, var(--primary-dark), var(--primary-color));
     color: white;
     transform: translateY(-2px);
+    border-color: transparent;
 }
 
 /* 模态框样式 */
@@ -318,16 +326,18 @@
 }
 
 .modal-content {
-    background-color: white;
+    background-color: #fff;
     margin: 2% auto;
     padding: 0;
-    border-radius: 20px;
+    border-radius: 26px;
     width: 95%;
     max-width: 1000px;
     max-height: 90vh;
     overflow-y: auto;
     position: relative;
     animation: modalSlideIn 0.3s ease;
+    box-shadow: 0 40px 90px rgba(47, 28, 25, 0.25);
+    border: 1px solid rgba(179, 26, 29, 0.12);
 }
 
 .video-modal {
@@ -351,7 +361,7 @@
     top: 20px;
     font-size: 28px;
     font-weight: bold;
-    color: #aaa;
+    color: rgba(47, 28, 25, 0.4);
     cursor: pointer;
     z-index: 10;
     transition: color 0.3s ease;
@@ -365,7 +375,7 @@
 }
 
 .close:hover {
-    color: #e74c3c;
+    color: var(--primary-color);
 }
 
 .modal-body {
@@ -407,12 +417,12 @@
 }
 
 .video-details {
-    padding: 2rem;
+    padding: 2.2rem;
 }
 
 .video-detail-title {
     font-size: 1.8rem;
-    color: #2c3e50;
+    color: var(--primary-dark);
     margin-bottom: 1.5rem;
     line-height: 1.4;
 }
@@ -428,20 +438,20 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    background: #f8f9fa;
-    padding: 8px 12px;
-    border-radius: 10px;
+    background: rgba(179, 26, 29, 0.08);
+    padding: 8px 14px;
+    border-radius: 12px;
     font-size: 0.9rem;
-    color: #666;
+    color: var(--primary-dark);
 }
 
 .meta-item i {
-    color: #e74c3c;
+    color: var(--primary-color);
     width: 16px;
 }
 
 .video-detail-description h3 {
-    color: #2c3e50;
+    color: var(--primary-dark);
     font-size: 1.2rem;
     margin-bottom: 1rem;
     margin-top: 1.5rem;
@@ -452,14 +462,14 @@
 }
 
 .video-detail-description p {
-    color: #666;
-    line-height: 1.7;
+    color: var(--muted-text);
+    line-height: 1.8;
     margin-bottom: 1rem;
 }
 
 .video-detail-description ul {
-    color: #666;
-    line-height: 1.7;
+    color: var(--muted-text);
+    line-height: 1.8;
     margin-bottom: 1rem;
     padding-left: 1.5rem;
 }
@@ -582,13 +592,14 @@
     text-align: center;
     margin: 2rem 0;
     padding: 1.5rem;
-    background: white;
-    border-radius: 15px;
-    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+    background: var(--surface-color);
+    border-radius: 20px;
+    box-shadow: var(--card-shadow);
+    border: var(--card-border);
 }
 
 .videos-stats h3 {
-    color: #2c3e50;
+    color: var(--primary-dark);
     margin-bottom: 1rem;
     font-size: 1.5rem;
 }
@@ -601,21 +612,21 @@
 }
 
 .stat-item {
-    background: #f8f9fa;
+    background: rgba(179, 26, 29, 0.08);
     padding: 1rem;
-    border-radius: 10px;
+    border-radius: 14px;
     text-align: center;
 }
 
 .stat-number {
     font-size: 2rem;
     font-weight: 700;
-    color: #e74c3c;
+    color: var(--primary-color);
     display: block;
 }
 
 .stat-label {
-    color: #666;
+    color: var(--muted-text);
     font-size: 0.9rem;
     margin-top: 0.5rem;
 }
@@ -630,16 +641,16 @@
     width: 100%;
     max-width: 500px;
     padding: 15px 25px;
-    border: 2px solid #e74c3c;
+    border: 1px solid rgba(179, 26, 29, 0.25);
     border-radius: 30px;
     font-size: 1rem;
     outline: none;
     transition: all 0.3s ease;
-    background: white;
+    background: rgba(179, 26, 29, 0.05);
 }
 
 .search-input:focus {
-    box-shadow: 0 0 20px rgba(231, 76, 60, 0.2);
+    box-shadow: 0 0 25px rgba(179, 26, 29, 0.18);
     transform: translateY(-2px);
 }
 


### PR DESCRIPTION
## Summary
- replace the global palette, navigation, hero layout, and shared components with a Kyocera-inspired red-and-neutral design
- restyle the stories, books, videos, and sitemap pages so their cards, tabs, and modals inherit the new theme

## Testing
- not run (static CSS changes)

------
https://chatgpt.com/codex/tasks/task_e_68cabe3243d88321ab720b3cf31d40df