### PR TITLE
Improve landing hero image presentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,7 +220,11 @@
                 </div>
             </div>
             <div class="hero-image">
-                <img src="zengguofan.png" alt="曾国藩像 - 晚清中兴名臣曾国藩肖像">
+                <div class="hero-image-ring" aria-hidden="true"></div>
+                <div class="hero-image-glow" aria-hidden="true"></div>
+                <div class="portrait-container">
+                    <img src="zengguofan.png" class="portrait-image" alt="曾国藩像 - 晚清中兴名臣曾国藩肖像">
+                </div>
             </div>
         </div>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -337,24 +337,59 @@ p {
     justify-content: center;
     align-items: center;
     position: relative;
+    justify-self: center;
+    width: 100%;
+    max-width: 440px;
+    margin: 0 auto;
+    padding: 12px 0;
+    z-index: 1;
+}
+
+.hero-image-ring,
+.hero-image-glow {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -48%);
+    border-radius: 50%;
+    pointer-events: none;
+    z-index: 0;
+}
+
+.hero-image-ring {
+    width: clamp(320px, 36vw, 460px);
+    height: clamp(320px, 36vw, 460px);
+    border: 1.5px solid rgba(255, 255, 255, 0.45);
+    opacity: 0.55;
+}
+
+.hero-image-glow {
+    width: clamp(260px, 32vw, 420px);
+    height: clamp(260px, 32vw, 420px);
+    background: radial-gradient(circle at 50% 55%, rgba(179, 26, 29, 0.42), rgba(179, 26, 29, 0));
+    opacity: 0.75;
+    filter: blur(0px);
 }
 
 .portrait-container {
-    width: 320px;
-    height: 430px;
+    width: clamp(260px, 28vw, 360px);
+    aspect-ratio: 3 / 4;
     border-radius: 28px;
     overflow: hidden;
     box-shadow: var(--card-shadow);
     border: 1px solid rgba(179, 26, 29, 0.15);
     background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(240, 226, 214, 0.6));
     position: relative;
+    display: flex;
+    align-items: stretch;
     transition: transform 0.4s ease, box-shadow 0.4s ease;
+    z-index: 1;
 }
 
 .portrait-container::after {
     content: '';
     position: absolute;
-    inset: 18px;
+    inset: clamp(12px, 4vw, 18px);
     border-radius: 20px;
     border: 1px solid rgba(255, 255, 255, 0.35);
     pointer-events: none;
@@ -368,6 +403,7 @@ p {
 .portrait-image {
     width: 100%;
     height: 100%;
+    display: block;
     object-fit: cover;
     object-position: center;
     transition: transform 0.4s ease;
@@ -1001,10 +1037,18 @@ p {
         justify-content: center;
         flex-wrap: wrap;
     }
-    
+
+    .hero-image {
+        max-width: 320px;
+    }
+
+    .hero-image-ring,
+    .hero-image-glow {
+        display: none;
+    }
+
     .portrait-container {
-        width: 250px;
-        height: 330px;
+        width: min(260px, 70vw);
     }
     
     .timeline::before {
@@ -1066,19 +1110,22 @@ p {
     .hero-title {
         font-size: 2rem;
     }
-    
+
     .hero-description {
         font-size: 1rem;
     }
-    
+
+    .hero-image {
+        max-width: 260px;
+    }
+
     .btn {
         padding: 10px 20px;
         font-size: 0.9rem;
     }
-    
+
     .portrait-container {
-        width: 200px;
-        height: 260px;
+        width: min(220px, 80vw);
     }
     
     .philosophy-card,


### PR DESCRIPTION
## Summary
- Wrap the landing hero portrait in a dedicated container and add decorative elements for a more polished layout
- Tune hero image styling to be responsive with gradients, ring accents, and refined mobile breakpoints so the portrait displays cleanly across screen sizes

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cb34c49fd883218c148735644219ac