### PR TITLE
Add Hotspot Game link to homepage navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,6 +189,7 @@
                 <li><a href="#learning">了解曾国藩</a></li>
                 <li><a href="books.html">著作文献</a></li>
                 <li><a href="videos.html">热门视频</a></li>
+                <li><a href="https://hotspotgame.online/" target="_blank" rel="noopener noreferrer">热点游戏</a></li>
                 <li><a href="stories.html">故事集</a></li>
                 <li><a href="#legacy">历史影响</a></li>
                 <li><a href="#faq">常见问题</a></li>


### PR DESCRIPTION
## Summary
- add a Hotspot Game menu item to the homepage navigation that opens the external site in a new tab

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e0c22b52688321a469faef465bfa4c